### PR TITLE
Store generated files in a temporary directory created at import time

### DIFF
--- a/plyplus/__init__.py
+++ b/plyplus/__init__.py
@@ -1,8 +1,19 @@
 from __future__ import absolute_import
 
+import os
+from tempfile import gettempdir
+
+PLYPLUS_DIR = os.path.join(gettempdir(), 'plyplus')
+
+try:
+    os.mkdir(PLYPLUS_DIR)
+except OSError:
+    pass
+
 from .plyplus import Grammar, SVisitor, STransformer, is_stree
 
 from .plyplus import PlyplusException, GrammarException, TokenizeError, ParseError
 
 from . import selector
 selector.install()
+

--- a/plyplus/grammar_parser.py
+++ b/plyplus/grammar_parser.py
@@ -5,6 +5,7 @@ from ply import yacc
 from .strees import STree as S
 
 from .grammar_lexer import tokens, lexer
+from . import PLYPLUS_DIR
 
 DEBUG = False
 YACC_TAB_MODULE = "plyplus_grammar_parsetab"
@@ -123,7 +124,7 @@ def p_error(p):
 start = "extgrammar"
 
 
-_parser = yacc.yacc(debug=DEBUG, tabmodule=YACC_TAB_MODULE, errorlog=Exception)     # Return parser object
+_parser = yacc.yacc(debug=DEBUG, tabmodule=YACC_TAB_MODULE, errorlog=Exception, outputdir=PLYPLUS_DIR)     # Return parser object
 def parse(text, debug=False):
     lexer.lineno = 1
     return _parser.parse(text, lexer=lexer, debug=debug)

--- a/plyplus/plyplus.py
+++ b/plyplus/plyplus.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.INFO)
 
 from ply import lex, yacc
 
-from . import grammar_parser
+from . import PLYPLUS_DIR, grammar_parser
 from .utils import StringTypes, StringType
 
 from .strees import STree, SVisitor, STransformer, is_stree, Str
@@ -67,7 +67,6 @@ from .strees import STree, SVisitor, STransformer, is_stree, Str
 #DONE: Multi-line comments
 #DONE: Better error handling (choose between prints and raising exception, setting threshold, etc.)
 #
-
 
 def get_token_name(token, default):
     return {
@@ -512,6 +511,7 @@ class _Grammar(object):
         self.ignore_postproc = bool(options.pop('ignore_postproc', False))
         self.auto_filter_tokens = bool(options.pop('auto_filter_tokens', True))
         self.tree_class = options.pop('tree_class', STree)
+
         if options:
             raise TypeError("Unknown options: %s"%options.keys())
 
@@ -558,7 +558,7 @@ class _Grammar(object):
 
         # -- Build Parser --
         if not self.just_lex:
-            self.parser = yacc.yacc(module=self, debug=self.debug, tabmodule=tab_filename, errorlog=self.logger)
+            self.parser = yacc.yacc(module=self, debug=self.debug, tabmodule=tab_filename, errorlog=self.logger, outputdir=PLYPLUS_DIR)
 
     def __repr__(self):
         return '<Grammar from %s, tab at %s>' % (self.source_name, self.tab_filename)


### PR DESCRIPTION
/cc @volpino 

We're using plyplus in a django project and we use linters to check the source quality. Pylint, specifically, lacks the feature to ignore files based on regular expressions, so there's no way to exclude the grammar's generated files.

Moreover, as we use jenkins for testing our application, there's no way to know if the current directory is writable or not (actually, the same issue may be valid in production, using supervisor for running the process).
