### PR TITLE
Adding thread safe QA to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Q. So what is Plyplus' first priority?
 
 A. Power and simplicity. See the examples and judge for yourself.
 
+Q. I want to use Plyplus in a threaded application. Is it thread safe?
+
+A. Yes, but you must pay attention. Plyplus relies on PLY, it can cause problems if you try to define multiple parsers at the same time using threads. Please make sure not to do that.
+
+
 ## Tutorials
 
 Learn how to write a grammar for Plyplus at the [tutorial](/docs/tutorial.md)


### PR DESCRIPTION
We encountered some issues while using Plyplus and Django: with concurrent requests the parser broke with random errors while with sequential requests everything was working well.

We were instantiating the parser in the `__init__` of a Django ClassBasedView so I tried to move the instantiation to the get() method but nothing changed (it is possible to test the issue with a simple ab -c 5 -n 5).

I found this:

```
# The current implementation is only somewhat object-oriented. The
# LR parser itself is defined in terms of an object (which allows multiple
# parsers to co-exist).  However, most of the variables used during table
# construction are defined in terms of global variables.  Users shouldn't
# notice unless they are trying to define multiple parsers at the same
# time using threads (in which case they should have their head examined).
```

in http://svn.openfoundry.org/pugs/v6/v6-Python/ply/yacc.py

So I tried to move the instantiation of the parsers to a global variable and it worked :) I think it's better to document this for other users.

Thanks for your work!
