### PR TITLE
Use closures instead of exec and attach location info when we *do* exec()

### DIFF
--- a/plyplus/grammar_lexer.py
+++ b/plyplus/grammar_lexer.py
@@ -34,10 +34,14 @@ t_RPAR = '\)'
 t_COLON = ':'
 t_SEMICOLON = ';'
 t_REGEXP = r"'(.|\n)*?[^\\]'"
-t_SECTION = '\#\#\#(.|\\n)*'
 t_LCURLY = '{'
 t_RCURLY = '}'
 
+def t_SECTION(t):
+    r'\#\#\#(.|\n)*'
+    # line number information used to ensure tracebacks refer to the correct line
+    t.lineno = t.lexer.lineno
+    return t
 
 def t_COMMENT(t):
     r'//[^\n]*\n|/[*](.|\n)*?[*]/'

--- a/plyplus/grammar_parser.py
+++ b/plyplus/grammar_parser.py
@@ -13,9 +13,15 @@ YACC_TAB_MODULE = "plyplus_grammar_parsetab"
 
 def p_extgrammar(p):
     """extgrammar : grammar
-                  | grammar SECTION
     """
     p[0] = S('extgrammar', p[1:])
+
+def p_extgrammar_with_code(p):
+    """extgrammar : grammar SECTION
+    """
+    p[0] = S('extgrammar', p[1:])
+    # preserve line-number information in AST, used for tracebacks
+    p[0].tail[-1].line = p.slice[2].lineno
 
 def p_grammar(p):
     """grammar  : def

--- a/plyplus/plyplus.py
+++ b/plyplus/plyplus.py
@@ -593,7 +593,13 @@ class _Grammar(object):
             ply_grammar, = ply_grammar_and_code
         else:
             ply_grammar, code = ply_grammar_and_code
-            exec(code, locals())
+
+            # prefix with newlines to get line-number count correctly (ensures tracebacks are correct)
+            src_code = '\n' * (max(code.line, 1) - 1) + code
+
+            # compiling before executing attaches source_name as filename: shown in tracebacks
+            exec_code = compile(src_code, source_name, 'exec')
+            exec(exec_code, locals())
 
         for x in ply_grammar:
             type_, (name, defin) = x.head, x.tail


### PR DESCRIPTION
This pull request does two things:
- replace usage of exec() with closures instead (for lexer and parser rule callback functions)
- preserves and attaches location information when executing code SECTIONs (following the '###') from grammars
