### PR TITLE
Typo in python test grammar.

### DIFF
--- a/plyplus/test/python.g
+++ b/plyplus/test/python.g
@@ -259,7 +259,7 @@ LPAREN: '\(';
 RPAREN: '\)';
 LBRACK: '\[';
 RBRACK: '\]';
-LCURLY: '\(';
+LCURLY: '\{';
 RCURLY: '\}';
 COLON: ':';
 SEMICOLON: ';';


### PR DESCRIPTION
There was a typo. I saw it fixed in https://github.com/erezsh/plyplus/pull/5, but it wasn't merged.