### PR TITLE
Invalid errorlog being passed to yacc in grammer_parser.py

### DIFF
--- a/plyplus/grammar_parser.py
+++ b/plyplus/grammar_parser.py
@@ -150,7 +150,7 @@ def p_error(p):
 start = "extgrammar"
 
 
-_parser = yacc.yacc(debug=DEBUG, tabmodule=YACC_TAB_MODULE, errorlog=Exception, outputdir=PLYPLUS_DIR)     # Return parser object
+_parser = yacc.yacc(debug=DEBUG, tabmodule=YACC_TAB_MODULE, outputdir=PLYPLUS_DIR)     # Return parser object
 def parse(text, debug=False):
     lexer.lineno = 1
     return _parser.parse(text, lexer=lexer, debug=debug)


### PR DESCRIPTION
In `grammer_parser.py`, `Exception` is being passed in as the `errorlog` parameter into `yacc()` instead of an actual logger. In the event that something is to be logged, the following exception is raised:

> exceptions.AttributeError: type object 'exceptions.Exception' has no attribute 'warning'

The underlying issue causing the warning is also masked because of the exception.

We can either pass in a valid logger or omit the `errorlog` parameter altogether, which will default to logging everything to `sys.stderr`.