### PR TITLE
Use unique temporary directory

### DIFF
--- a/plyplus/__init__.py
+++ b/plyplus/__init__.py
@@ -2,12 +2,13 @@
 
 from __future__ import absolute_import
 
+from getpass import getuser
 import os
 from tempfile import gettempdir
 
 __version__ = "0.6.1"
 
-PLYPLUS_DIR = os.path.join(gettempdir(), 'plyplus')
+PLYPLUS_DIR = os.path.join(gettempdir(), 'plyplus-' + getuser())
 
 try:
     os.mkdir(PLYPLUS_DIR)


### PR DESCRIPTION
A new, unique temporary directory should be used. This can be done using `tempfile.mkdtemp()` instead of hardcoding it to `os.path.join(gettempdir(), 'plyplus')`.

In my case, I have two users on the same filesystem running the same application (or could be two different applications both using plyplus). By running the application, a temporary directory is created with the first user's ID, which is unable to be read/written to by the second user.