### PR TITLE
Support unicode in tokens

### DIFF
--- a/plyplus/plyplus.py
+++ b/plyplus/plyplus.py
@@ -768,7 +768,7 @@ class _Grammar(object):
         # token_value = token_value.replace(r'\n', r'\\n')
         # token_value = token_value.replace(r'\r', r'\\r')
         # token_value = token_value.replace(r'\f', r'\\f')
-        # but for speed reasons, I ended-up with this ridiculus regexp:
+        # but for speed reasons, I ended-up with this ridiculous regexp:
         token_value = re.sub(r'(\\[nrf])', r'\\\1', token_value)
 
         return codecs.getdecoder('unicode_escape')(token_value)[0]

--- a/plyplus/plyplus.py
+++ b/plyplus/plyplus.py
@@ -754,28 +754,9 @@ class _Grammar(object):
 
         return unless_toks_dict, unless_toks_regexps
 
-    def _unescape_unicode_in_token(self, token_value):
-        # XXX HACK XXX
-        # We want to convert unicode escapes into unicode characters,
-        # because the regexp engine only supports the latter.
-        # But decoding with unicode-escape converts whitespace as well,
-        # which is bad because our regexps are whitespace agnostic.
-        # It also unescapes double backslashes, which messes up with the
-        # regexp.
-
-        token_value = token_value.replace('\\'*2, '\\'*4)
-        # The equivalent whitespace escaping is:
-        # token_value = token_value.replace(r'\n', r'\\n')
-        # token_value = token_value.replace(r'\r', r'\\r')
-        # token_value = token_value.replace(r'\f', r'\\f')
-        # but for speed reasons, I ended-up with this ridiculous regexp:
-        token_value = re.sub(r'(\\[nrf])', r'\\\1', token_value)
-
-        return codecs.getdecoder('unicode_escape')(token_value)[0]
-
     def _add_token_with_mods(self, name, defin):
         token_value, token_features = defin
-        token_value = self._unescape_unicode_in_token(token_value)
+        token_value = token_value
 
         token_added = False
         if token_features is None:

--- a/plyplus/test/__main__.py
+++ b/plyplus/test/__main__.py
@@ -7,6 +7,7 @@ from .test_trees import TestSTrees
 from .test_selectors import TestSelectors
 from .test_parser import TestPlyPlus
 from .test_grammars import TestPythonG, TestConfigG
+from .test_unicode_grammar import TestUnicode
 
 logging.basicConfig(level=logging.INFO)
 

--- a/plyplus/test/test_parser.py
+++ b/plyplus/test/test_parser.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 
 import unittest
@@ -73,11 +75,11 @@ class TestPlyPlus(unittest.TestCase):
         Grammar(uStringIO(u"start: a+ b a+? 'b' a*; b: 'b'; a: 'a';"))
 
     def test_unicode(self):
-        g = Grammar(r"""start: UNIA UNIB UNIA;
-                    UNIA: '\xa3';
-                    UNIB: '\u0101';
+        g = Grammar(u"""start: UNIA UNIB UNIA;
+                    UNIA: '£';
+                    UNIB: 'ā';
                     """)
-        g.parse(u'\xa3\u0101\u00a3')
+        g.parse(u'£ā£')
 
     def test_recurse_expansion(self):
         """Verify that stack depth doesn't get exceeded on recursive rules marked for expansion."""

--- a/plyplus/test/test_unicode_grammar.py
+++ b/plyplus/test/test_unicode_grammar.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import codecs
+import os
+import unittest
+
+from plyplus.plyplus import Grammar, ParseError
+
+class TestUnicode(unittest.TestCase):
+    def test_non_unicode(self):
+        """Test a basic grammar without unicode"""
+        g = Grammar('''
+            start: a b?;
+            a: 'a';
+            b: 'b';
+            ''')
+        r = g.parse('a')
+        self.assertEqual(''.join(x.head for x in r.tail), 'a')
+        r = g.parse('ab')
+        self.assertEqual(''.join(x.head for x in r.tail), 'ab')
+
+        with self.assertRaises(ParseError):
+            g.parse('b')
+
+    def test_basic_unicode(self):
+        """Test a basic grammar with unicode"""
+        g = Grammar(u'''
+            start: arrow? period;
+            arrow: '→';
+            period: '\.';
+            ''')
+        r = g.parse('.')
+        self.assertEqual(''.join(x.head for x in r.tail), 'period')
+        r = g.parse(u'→.')
+        self.assertEqual(' '.join(x.head for x in r.tail), 'arrow period')
+        self.assertEqual(''.join(r.tail[0].tail), u'→')
+
+        with self.assertRaisesRegexp(ParseError, 'Syntax error'):
+            g.parse(u'→')
+
+    def test_from_file(self):
+        """Test reading a unicode grammar from a UTF-8 file"""
+        me = os.path.abspath(__file__)
+        grammar = os.path.join(os.path.dirname(me), 'unicode_grammar.g')
+
+        with codecs.open(grammar, 'r', 'utf-8') as f:
+            g = Grammar(f.read())
+
+        r = g.parse('.')
+        self.assertEqual(''.join(x.head for x in r.tail), 'period')
+        r = g.parse(u'→.')
+        self.assertEqual(' '.join(x.head for x in r.tail), 'arrow period')
+        self.assertEqual(''.join(r.tail[0].tail), u'→')
+
+        with self.assertRaisesRegexp(ParseError, 'Syntax error'):
+            g.parse(u'→')
+
+    def test_mixed_token(self):
+        """Test a grammar that involves a token with unicode and ascii"""
+        g = Grammar(u'''
+            start: a b?;
+            a: 'aā';
+            b: '£b';
+            ''')
+
+        r = g.parse(u'aā')
+        self.assertEqual(''.join(x.head for x in r.tail), 'a')
+        self.assertEqual(''.join(r.tail[0].tail), u'aā')
+        r = g.parse(u'aā£b')
+        self.assertEqual(''.join(x.head for x in r.tail), 'ab')
+        self.assertEqual(''.join(r.tail[0].tail), u'aā')
+        self.assertEqual(''.join(r.tail[1].tail), u'£b')
+
+        with self.assertRaises(ParseError):
+            g.parse(u'£b')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plyplus/test/unicode_grammar.g
+++ b/plyplus/test/unicode_grammar.g
@@ -1,0 +1,3 @@
+start: arrow? period;
+arrow: '→';
+period: '\.';


### PR DESCRIPTION
I grappled with supporting this in `_unescape_unicode_in_token` before deciding it was simpler to just drop this function and support unicode literals. A side-effect of this is that we've lost support for unicode and byte escapes (`\u....` and `\x..`). Going back and forth with various different attempts here, I've formed the opinion that it doesn't seem straightforward to support both without more brittle regexing.

What are your thoughts about this? I can understand these changes might be unacceptable because they remove some previous functionality. However, my thinking was that users are unlikely to be working with unicode tokens unless they have an environment that supports unicode literals in the grammar source.

I can also add more test cases if there's anything you can think of that might be particularly tricky.