### PR TITLE
Mark package as not zip safe

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[global]
+zip_safe=


### PR DESCRIPTION
This line makes this package not zip safe: 

https://github.com/erezsh/plyplus/blob/5a4c8cbe6931635924f234a83b3ff8fb3124476d/plyplus/grammars/__init__.py#L5

This PR marks the package as not zip safe.

Fixes https://github.com/erezsh/plyplus/issues/35

